### PR TITLE
conan: don't export civetweb submodule code

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class mediagraphConan(ConanFile):
     topics = ("conan", "pipeline", "media", "multi-threading")
     
     exports = ("LICENSE.md", "README.md")
-    exports_sources = ("*")
+    exports_sources = ("*", "!graphHttpServer/civetweb/*")
     
     generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
For conan we depend on civetweb and we don't want to export the civetweb code if the gitmodule was cloned